### PR TITLE
Fix incorrect indicator location issue

### DIFF
--- a/AndroidBottomBar/src/main/java/com/skydoves/androidbottombar/AndroidBottomBarView.kt
+++ b/AndroidBottomBar/src/main/java/com/skydoves/androidbottombar/AndroidBottomBarView.kt
@@ -339,14 +339,18 @@ class AndroidBottomBarView @JvmOverloads constructor(
       object : ViewPager.OnPageChangeListener {
         override fun onPageScrollStateChanged(state: Int) = Unit
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-          if (isInticatorInitialized.compareAndSet(false, true)) {
-            indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
-            return
-          }
-          if ((selectedIndex > position && previousPosition < positionOffset)) {
-            post {
-              indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding
-              previousPosition = positionOffset
+          when {
+            (isInticatorInitialized.compareAndSet(false, true)) -> {
+              post {
+                indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
+                previousPosition = positionOffset
+              }
+            }
+            (selectedIndex > position && previousPosition < positionOffset) -> {
+              post {
+                indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding
+                previousPosition = positionOffset
+              }
             }
           }
         }
@@ -368,14 +372,18 @@ class AndroidBottomBarView @JvmOverloads constructor(
       object : ViewPager2.OnPageChangeCallback() {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
           super.onPageScrolled(position, positionOffset, positionOffsetPixels)
-          if (isInticatorInitialized.compareAndSet(false, true)) {
-            indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
-            return
-          }
-          if ((selectedIndex > position && previousPosition < positionOffset)) {
-            post {
-              indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding
-              previousPosition = positionOffset
+          when {
+            (isInticatorInitialized.compareAndSet(false, true)) -> {
+              post {
+                indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
+                previousPosition = positionOffset
+              }
+            }
+            (selectedIndex > position && previousPosition < positionOffset) -> {
+              post {
+                indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding
+                previousPosition = positionOffset
+              }
             }
           }
         }

--- a/AndroidBottomBar/src/main/java/com/skydoves/androidbottombar/AndroidBottomBarView.kt
+++ b/AndroidBottomBar/src/main/java/com/skydoves/androidbottombar/AndroidBottomBarView.kt
@@ -38,6 +38,7 @@ import com.skydoves.androidbottombar.extensions.dp2Px
 import com.skydoves.androidbottombar.extensions.resourceDrawable
 import com.skydoves.androidbottombar.extensions.translateX
 import com.skydoves.androidbottombar.extensions.visible
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * AndroidBottomBarView is a lightweight bottom navigation view,
@@ -150,6 +151,8 @@ class AndroidBottomBarView @JvmOverloads constructor(
     }
 
   private var previousPosition: Float = 0f
+
+  private val isInticatorInitialized = AtomicBoolean(false)
 
   init {
     obtainStyledAttributes(attrs, defStyleAttr)
@@ -336,6 +339,10 @@ class AndroidBottomBarView @JvmOverloads constructor(
       object : ViewPager.OnPageChangeListener {
         override fun onPageScrollStateChanged(state: Int) = Unit
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+          if (isInticatorInitialized.compareAndSet(false, true)) {
+            indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
+            return
+          }
           if ((selectedIndex > position && previousPosition < positionOffset)) {
             post {
               indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding
@@ -361,6 +368,10 @@ class AndroidBottomBarView @JvmOverloads constructor(
       object : ViewPager2.OnPageChangeCallback() {
         override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
           super.onPageScrolled(position, positionOffset, positionOffsetPixels)
+          if (isInticatorInitialized.compareAndSet(false, true)) {
+            indicator.x = (itemWidth * selectedIndex + indicatorPadding).toFloat()
+            return
+          }
           if ((selectedIndex > position && previousPosition < positionOffset)) {
             post {
               indicator.x = itemWidth * position + itemWidth * positionOffset + indicatorPadding


### PR DESCRIPTION
Fixed Issue ➡️ #8 

This issue seems to be happen when navigation bar is initialized at first time. But this bug is occurred depends on onPageScrolled's parameters `position` and `positionOffset`. So i think we need to enforce location of the indicator at first time. WDYT? Please let me know if you have any concern about my approach @skydoves 